### PR TITLE
require node 16 dues to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/o0shojo0o/ioBroker.traccar"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "axios": "^1.3.2",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 or lower due to npm6 not installing peer-dependencies. So this adapter requires node 16 or newer